### PR TITLE
Fix Tifawin layout and populate How we work

### DIFF
--- a/components/FeatureGrid.vue
+++ b/components/FeatureGrid.vue
@@ -10,7 +10,7 @@
         </p>
       </div>
 
-      <div class="grid-cards">
+      <div :class="gridClass || 'grid-cards'">
         <div
           v-for="(feature, index) in features"
           :key="feature.title"
@@ -59,6 +59,7 @@ interface Props {
   title: string
   subtitle: string
   features: Feature[]
+  gridClass?: string
 }
 
 defineProps<Props>()

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -33,6 +33,7 @@
       title="Why choose Tifawin?"
       subtitle="We combine technical expertise with creative vision to deliver solutions that drive real business results."
       :features="valueProps"
+      gridClass="grid-cards-4"
     />
 
     <!-- Featured Services -->
@@ -91,19 +92,11 @@
     </section>
 
     <!-- Process -->
-    <section class="section">
-      <div class="container-custom">
-        <div class="text-center mb-16">
-          <div class="eyebrow mb-4">Our Process</div>
-          <h2 class="heading-section mb-4">
-            How we work
-          </h2>
-          <p class="text-xl text-muted-600 dark:text-muted-400 max-w-3xl mx-auto leading-7">
-            Our proven process ensures your project is delivered on time, on budget, and exceeds expectations.
-          </p>
-        </div>
-      </div>
-    </section>
+    <Steps
+      title="How we work"
+      subtitle="Our proven process ensures your project is delivered on time, on budget, and exceeds expectations."
+      :steps="processSteps"
+    />
 
     <!-- Case Study Highlights -->
     <section class="section">


### PR DESCRIPTION
Update "Why choose Tifawin" to a 4-column layout and populate the "How we work" section.

---
<a href="https://cursor.com/background-agent?bcId=bc-854ff79b-c3cc-454d-a5c0-0d370dc34be9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-854ff79b-c3cc-454d-a5c0-0d370dc34be9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

